### PR TITLE
Bug Fix for Deprecated Unauthenticated Git Protocol

### DIFF
--- a/ghorgsync.py
+++ b/ghorgsync.py
@@ -102,8 +102,8 @@ class GHOrgSync(object):
             'private'   : (bool) is this a private repository?
             'sshurl'    : (str) SSH URL of the repository; e.g., 
                                 git@github.com:NOAA-PMEL/PyFerret.git
-            'giturl'    : (str) git URL of the repository; e.g.,
-                                git://github.com/NOAA-PMEL/PyFerret.git
+            'cloneurl'  : (str) HTTPS clone URL of the repository; e.g.,
+                                https://github.com/NOAA-PMEL/PyFerret.git
             'parenturl' : (str) SSH URL of the parent GitHub repository, or
                                 an empty string if this repository is not
                                 a fork of another GitHub repository
@@ -134,7 +134,7 @@ class GHOrgSync(object):
                 private = bool(repo[u'private'])
                 haswiki = bool(repo[u'has_wiki'])
                 sshurl = str(repo[u'ssh_url'])
-                giturl = str(repo[u'git_url'])
+                cloneurl = str(repo[u'clone_url'])
                 match = urlregex.match(sshurl)
                 if match and (match.group(1) == name):
                     if bool(repo[u'fork']):
@@ -152,7 +152,7 @@ class GHOrgSync(object):
                                   'private': private, 
                                   'haswiki': haswiki, 
                                   'sshurl': sshurl,
-                                  'giturl': giturl,
+                                  'cloneurl': cloneurl,
                                   'parenturl': parenturl})
                 else:
                     timestamp = datetime.today().isoformat(' ')
@@ -179,8 +179,8 @@ class GHOrgSync(object):
                 'private'   : (bool) is this a private repository?
                 'sshurl'    : (str) SSH URL of the repository; e.g., 
                                     git@github.com:NOAA-PMEL/PyFerret.git
-                'giturl'    : (str) git URL of the repository; e.g.,
-                                git://github.com/NOAA-PMEL/PyFerret.git
+                'cloneurl'  : (str) HTTPS clone URL of the repository; e.g.,
+                                    https://github.com/NOAA-PMEL/PyFerret.git
                 'parenturl' : (str) SSH URL of the parent GitHub repository to set 
                                     as the upstream repository when creating the 
                                     local clone.  If empty or None, or if the local 
@@ -191,7 +191,7 @@ class GHOrgSync(object):
         name = repo['name']
         private = repo['private']
         sshurl = repo['sshurl']
-        giturl = repo['giturl']
+        cloneurl = repo['cloneurl']
         parenturl = repo['parenturl']
         # Get the local clone location for this repo
         if private:
@@ -201,10 +201,9 @@ class GHOrgSync(object):
         clonedir = os.path.join(basedir, name)
         # Deal with this repo
         if not os.path.exists(clonedir):
-            cloneurl = sshurl
-            if not private:
-                # use Git protocol for public repos, per GitHub docs
-                cloneurl = giturl
+            if private:
+                # use SSH protocol for private repos
+                cloneurl = sshurl
             # New repo - clone it
             os.chdir(basedir)
             retval = subprocess.call(['git', 'clone', '--quiet', cloneurl])


### PR DESCRIPTION
This is a Pull Request to resolve a bug caused by the deprecated [Git protocol method](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git).  

Commit message: 
Updated the ghorgsync.py script to utilize the clone_URL value from the API request for a given GitHub organization's list of repositories instead of the deprecated git_url method (https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git) when cloning the repositories.

The change was tested for the on-prem implementation at PIFSC to clone all PIFSC GitHub repositories to a local linux server.